### PR TITLE
Fix use of incorrect pos and dts for captioning

### DIFF
--- a/src/org/mangui/hls/stream/StreamBuffer.as
+++ b/src/org/mangui/hls/stream/StreamBuffer.as
@@ -368,8 +368,8 @@ package org.mangui.hls.stream {
                         break;
                      case FLVTag.CAPTION_DATA:
                         captions.push({
-                            pos: _liveSlidingMain ? _liveSlidingMain + pos : pos,
-                            dts: _liveSlidingMain ? _liveSlidingMain + posDTS : posDTS,
+                            pos: _liveSlidingMain ? _liveSlidingMain + (tag.pts / 1000) : (tag.pts / 1000),
+                            dts: _liveSlidingMain ? _liveSlidingMain + (tag.dts / 1000) : (tag.dts / 1000),
                             data: tag.captionData
                         });
                         break;


### PR DESCRIPTION
Unclear on what exactly is incorrect with this calculation (and what else could break by "fixing" it), this modification will sent the current PTS and DTS forward along with the caption.  This should fix issues with captions being jumbled when parsed/fed in via mux.js.