### PR TITLE
fix: VOD playlists with one segment time out

### DIFF
--- a/src/org/mangui/hls/stream/StreamBuffer.as
+++ b/src/org/mangui/hls/stream/StreamBuffer.as
@@ -115,12 +115,23 @@ package org.mangui.hls.stream {
             _timer = null;
         }
 
+        public function get numberOfSegmentsInPlaylist() : int {
+          return _hls.levels[_hls.loadLevel].fragments.length;
+        }
+
         public function get seekingOutsideBuffer():Boolean {
             return _seekingOutsideBuffer;
         }
 
         public function get canAppendTags():Boolean {
-            return !(_seekingOutsideBuffer && _hls.isAltAudio && bufferLength <= _hls.stream.bufferThresholdController.minBufferLength);
+            /*
+             * If there is only one segment in a VOD playlist, return true. This
+             * isolates a case where content would never start because the below
+             * threshold comparison would always be false with single segment VOD content
+             * since the minBufferLength is equal to the target duration in that case
+             */
+            return _hls.type === HLSTypes.VOD && numberOfSegmentsInPlaylist === 1 ||
+              !(_seekingOutsideBuffer && _hls.isAltAudio && bufferLength <= _hls.stream.bufferThresholdController.minBufferLength);
         }
 
         public function stop() : void {


### PR DESCRIPTION
## Description
This [prior PR ](https://github.com/brightcove/flashls/pull/9) addressed a problem with choppy playback of HLSe. The nature of the fix was to wait until the bufferLength exceeded a minimum threshold before starting playback. However, the `minBufferLength` used in that threshold [comparison](https://github.com/brightcove/flashls/pull/9/files?w=1#diff-62c6cfcde05f38a40b856f45d540f6ddR123) is always equal to the target segment duration (see [here](https://github.com/brightcove/flashls/pull/9/files?w=1#diff-4d2cdb9d3798528cb952f4484584c8c2R43) and [here](https://github.com/brightcove/flashls/pull/9/files?w=1#diff-4d2cdb9d3798528cb952f4484584c8c2R59)), so in the case of playlists with only one segment, the bufferLength never exceeds it and playback never starts.

## Specific Proposed Additions
Isolate the problematic case by modifying the condition in `canAppendTags()` to return `true` if the content is a VOD playlist with only one segment.

**Caveat 1:** This fix will ensure that all multi and single-segment encrypted and non-encrypted content will play smoothly, with one exception: single segment encrypted content will still have a stutter. I experimented with adding a "fudge factor" to the threshold check to address this and was successful in using trial and error to find a fudge value that seemed to work, but ultimately I decided that such a hacky approach was not justified considering how unusual the case is. If you feel differently, we can re-examine the feasibility of that approach.

**Caveat 2:** Now that single segment playlists play rather than time out, it has revealed another bug: playback is audio-only for the first second or so before video becomes visible. This bug is apparently unrelated to any of the code unique to this fork, as it is reproducible in the sample players on flashls.org.